### PR TITLE
Fix: update recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyospackage" %}
-{% set version = "0.1.11" %}
+{% set version = "0.1.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyospackage-{{ version }}.tar.gz
-  sha256: 5ae7a8b193415cc7c487863c958d5a19ec5d369e1324321824a210741fdfd4dc
+  sha256: 7b463f7b385613d4e63ce2efb47fd380f2f2fb8c3efb23d503beece5e507a946
 
 build:
   noarch: python
@@ -16,11 +16,12 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - hatchling
+    - hatch-vcs
     - pip
   run:
-    - python >=3.9
+    - python >=3.10
 
 test:
   imports:
@@ -33,6 +34,7 @@ test:
 about:
   home: https://pypi.org/project/pyospackage/
   summary: A package that adds numbers together
+  doc_url: https://pyospackage.readthedocs.io/en/latest/
   dev_url: https://github.com/pyopensci/pyospackage
   license: MIT
   license_file: LICENSE


### PR DESCRIPTION
hatch vcs and python 3.10
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This fixes the dependency issue with the package that arose with the last automated pr here. 

I used grayskull to rebuild the recipe.
